### PR TITLE
Move traefik metrics to port 9109

### DIFF
--- a/nubis/puppet/files/confd/templates/traefik.toml.tmpl
+++ b/nubis/puppet/files/confd/templates/traefik.toml.tmpl
@@ -11,7 +11,7 @@ defaultEntryPoints = ["http","https"]
     [entryPoints.https.tls]
 
 [web]
-address = ":8082"
+address = ":9109"
     [web.metrics.prometheus]
 
 [consul]

--- a/nubis/puppet/files/svc-sso-traefik.json
+++ b/nubis/puppet/files/svc-sso-traefik.json
@@ -1,9 +1,9 @@
 {
   "service": {
     "name": "sso-traefik",
-    "port": 8082,
+    "port": 9109,
     "check": {
-       "http": "http://localhost:8082/health",
+       "http": "http://localhost:9109/health",
        "interval": "10s",
        "timeout": "1s"
     }


### PR DESCRIPTION
This fixes issue #38 and also allows us to open additional ports on the monitoring security group