### PR TITLE
Sleep scout before running

### DIFF
--- a/nubis/puppet/files/run-scout
+++ b/nubis/puppet/files/run-scout
@@ -1,4 +1,9 @@
 #!/bin/bash -l
 
+# Sleep for a random amount of time within 10 minutes
+# Startups are rough and we should make it sleep for a bit to let
+# the host settle down before running Scout
+sleep $(( $RANDOM % 600 ))
+
 nice -n 19 /usr/local/bin/Scout2 --force --no-browser  --report-dir /var/www/html/scout --ruleset /usr/local/bin/nubis-scout-ruleset.json &
 disown

--- a/nubis/puppet/files/run-scout
+++ b/nubis/puppet/files/run-scout
@@ -3,7 +3,7 @@
 # Sleep for a random amount of time within 10 minutes
 # Startups are rough and we should make it sleep for a bit to let
 # the host settle down before running Scout
-sleep $(( $RANDOM % 600 ))
+sleep $(( RANDOM % 600 ))
 
 nice -n 19 /usr/local/bin/Scout2 --force --no-browser  --report-dir /var/www/html/scout --ruleset /usr/local/bin/nubis-scout-ruleset.json &
 disown


### PR DESCRIPTION
Scout a random amount of time before running, this allows the host to settle down before running. We found out that when you run this during start up it can really kill the host in terms of load, so we put sleep to help it out a bit.

Fixes issue #26